### PR TITLE
Fix version merge field usage

### DIFF
--- a/src/collections/salesforce_apis/auth/soap_login.json
+++ b/src/collections/salesforce_apis/auth/soap_login.json
@@ -1,7 +1,7 @@
 {
   "id": "6f042d72-486a-40ed-954b-40036fb97c6f",
   "name": "SOAP Login",
-  "url": "{{url}}{{site}}/services/Soap/u/47.0",
+  "url": "{{url}}{{site}}/services/Soap/u/{{version}}",
   "description": null,
   "data": [],
   "dataOptions": null,

--- a/src/collections/salesforce_apis/rest/resources_by_version.json
+++ b/src/collections/salesforce_apis/rest/resources_by_version.json
@@ -1,7 +1,7 @@
 {
   "id": "22b51ae0-1e1e-49bb-874a-f938da3bbe07",
   "name": "Resources by Version",
-  "url": "{{endpoint}}/services/data//{{version}}/",
+  "url": "{{endpoint}}/services/data/{{version}}/",
   "description": "Lists available resources for the specified API version, including resource name and URI.",
   "data": [],
   "dataOptions": null,

--- a/src/collections/salesforce_apis/rest/resources_by_version.json
+++ b/src/collections/salesforce_apis/rest/resources_by_version.json
@@ -1,7 +1,7 @@
 {
   "id": "22b51ae0-1e1e-49bb-874a-f938da3bbe07",
   "name": "Resources by Version",
-  "url": "{{endpoint}}/services/data//v{version}.0/",
+  "url": "{{endpoint}}/services/data//{{version}}/",
   "description": "Lists available resources for the specified API version, including resource name and URI.",
   "data": [],
   "dataOptions": null,

--- a/src/environments/salesforce_template_environment.json
+++ b/src/environments/salesforce_template_environment.json
@@ -9,7 +9,7 @@
     },
     {
       "key": "version",
-      "value": "46.0",
+      "value": "48.0",
       "enabled": true
     },
     {


### PR DESCRIPTION
In "SOAP Login" apply the version
In "Resources by Version" use the right merge field
In the "Salesforce Template Environment" use the version 48