### PR TITLE
Fixed auth headers for UI API

### DIFF
--- a/src/collections/salesforce_apis/actions/get_global_actions.json
+++ b/src/collections/salesforce_apis/actions/get_global_actions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -41,6 +41,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/actions/get_lightning_page_actions.json
+++ b/src/collections/salesforce_apis/actions/get_lightning_page_actions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -41,6 +41,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/actions/get_list_view_chart_actions.json
+++ b/src/collections/salesforce_apis/actions/get_list_view_chart_actions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -41,6 +41,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/actions/get_list_view_header_actions.json
+++ b/src/collections/salesforce_apis/actions/get_list_view_header_actions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -41,6 +41,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/actions/get_list_view_record_actions.json
+++ b/src/collections/salesforce_apis/actions/get_list_view_record_actions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -41,6 +41,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/actions/get_lookup_field_actions.json
+++ b/src/collections/salesforce_apis/actions/get_lookup_field_actions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -41,6 +41,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/actions/get_mru_list_view_actions.json
+++ b/src/collections/salesforce_apis/actions/get_mru_list_view_actions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -41,6 +41,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/actions/get_photo_actions.json
+++ b/src/collections/salesforce_apis/actions/get_photo_actions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -41,6 +41,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/actions/get_record_detail_page_actions.json
+++ b/src/collections/salesforce_apis/actions/get_record_detail_page_actions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -41,6 +41,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/actions/get_record_edit_page_actions.json
+++ b/src/collections/salesforce_apis/actions/get_record_edit_page_actions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -41,6 +41,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/actions/get_related_list_actions.json
+++ b/src/collections/salesforce_apis/actions/get_related_list_actions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -41,6 +41,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/actions/get_related_list_record_actions.json
+++ b/src/collections/salesforce_apis/actions/get_related_list_record_actions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -41,6 +41,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/apps/get_all_navigation_items.json
+++ b/src/collections/salesforce_apis/apps/get_all_navigation_items.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/apps/get_an_app.json
+++ b/src/collections/salesforce_apis/apps/get_an_app.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/apps/get_apps.json
+++ b/src/collections/salesforce_apis/apps/get_apps.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/apps/get_last_selected_app.json
+++ b/src/collections/salesforce_apis/apps/get_last_selected_app.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/apps/get_personalized_navigation_items.json
+++ b/src/collections/salesforce_apis/apps/get_personalized_navigation_items.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/apps/update_last_selected_app.json
+++ b/src/collections/salesforce_apis/apps/update_last_selected_app.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "PATCH",
@@ -42,6 +42,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/apps/update_personalized_navigation_items.json
+++ b/src/collections/salesforce_apis/apps/update_personalized_navigation_items.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "PUT",
@@ -42,6 +42,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/favorites/create_a_favorite.json
+++ b/src/collections/salesforce_apis/favorites/create_a_favorite.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     },
     {
       "key": "Content-Type",
@@ -49,6 +49,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "{\n    \"name\": \"Favorite Name\",\n    \"sortOrder\": \"integer\",\n    \"target\": \"API Name or ID\",\n    \"targetType\": \"ListView | ObjectHome | Record | Tab\"\n}",
-  "headers": "Authorization: {{_accessToken}}\nContent-Type: application/json\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\nContent-Type: application/json\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/favorites/delete_a_favorite.json
+++ b/src/collections/salesforce_apis/favorites/delete_a_favorite.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "DELETE",
@@ -42,6 +42,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/favorites/get_a_favorite.json
+++ b/src/collections/salesforce_apis/favorites/get_a_favorite.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/favorites/get_favorites.json
+++ b/src/collections/salesforce_apis/favorites/get_favorites.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/favorites/update_a_batch_of_favorites.json
+++ b/src/collections/salesforce_apis/favorites/update_a_batch_of_favorites.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "PUT",
@@ -42,6 +42,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "{\n    \"favorites\": [\n        {\n            \"id\": \"0MVR00000004DhnOAE\",\n            \"name\": \"Q4 Perf\"\n        }\n    ]\n}",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/favorites/update_a_favorite.json
+++ b/src/collections/salesforce_apis/favorites/update_a_favorite.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "PATCH",
@@ -42,6 +42,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "{\n  \"name\": \"Red Accounts\",\n  \"sortOrder\": 1\n}\n",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/favorites/update_usage_of_a_favorite.json
+++ b/src/collections/salesforce_apis/favorites/update_usage_of_a_favorite.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "PATCH",
@@ -42,6 +42,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/list_views/get_list_view_for_an_object.json
+++ b/src/collections/salesforce_apis/list_views/get_list_view_for_an_object.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/list_views/get_list_view_metadata_per_api_name.json
+++ b/src/collections/salesforce_apis/list_views/get_list_view_metadata_per_api_name.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/list_views/get_list_view_metadata_per_id.json
+++ b/src/collections/salesforce_apis/list_views/get_list_view_metadata_per_id.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/list_views/get_list_view_records_and_metadata_api_name.json
+++ b/src/collections/salesforce_apis/list_views/get_list_view_records_and_metadata_api_name.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/list_views/get_list_view_records_and_metadata_per_id.json
+++ b/src/collections/salesforce_apis/list_views/get_list_view_records_and_metadata_per_id.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/list_views/get_list_view_records_per_api_name.json
+++ b/src/collections/salesforce_apis/list_views/get_list_view_records_per_api_name.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/list_views/get_list_view_records_per_id.json
+++ b/src/collections/salesforce_apis/list_views/get_list_view_records_per_id.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/list_views/get_most_recently_used_list_view_metadata.json
+++ b/src/collections/salesforce_apis/list_views/get_most_recently_used_list_view_metadata.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/list_views/get_most_recently_used_list_view_records.json
+++ b/src/collections/salesforce_apis/list_views/get_most_recently_used_list_view_records.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/list_views/get_most_recently_used_list_view_records_and_metadata.json
+++ b/src/collections/salesforce_apis/list_views/get_most_recently_used_list_view_records_and_metadata.json
@@ -16,7 +16,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/create_a_record.json
+++ b/src/collections/salesforce_apis/records/create_a_record.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     },
     {
       "key": "Content-Type",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "{\n    \"allowSaveOnDuplicate\": false,\n    \"apiName\": \"Object\",\n    \"fields\": {\n        \"FieldAPIName\": \"FieldValue\"\n    }\n}",
-  "headers": "Authorization: {{_accessToken}}\nContent-Type: application/json\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\nContent-Type: application/json\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/delete_a_record.json
+++ b/src/collections/salesforce_apis/records/delete_a_record.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "DELETE",
@@ -38,6 +38,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_a_batch_of_records.json
+++ b/src/collections/salesforce_apis/records/get_a_batch_of_records.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -67,6 +67,6 @@
   "currentHelper": null,
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_a_directory_of_supported_objects.json
+++ b/src/collections/salesforce_apis/records/get_a_directory_of_supported_objects.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -24,6 +24,6 @@
   "currentHelper": null,
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_a_record.json
+++ b/src/collections/salesforce_apis/records/get_a_record.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -67,6 +67,6 @@
   "currentHelper": null,
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_child_records.json
+++ b/src/collections/salesforce_apis/records/get_child_records.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -55,6 +55,6 @@
   "currentHelper": null,
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_default_values_to_clone_a_record.json
+++ b/src/collections/salesforce_apis/records/get_default_values_to_clone_a_record.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -60,6 +60,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_default_values_to_create_a_record.json
+++ b/src/collections/salesforce_apis/records/get_default_values_to_create_a_record.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -60,6 +60,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_lookup_field_suggestions.json
+++ b/src/collections/salesforce_apis/records/get_lookup_field_suggestions.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -72,6 +72,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_lookup_field_suggestions_for_a_specified_object.json
+++ b/src/collections/salesforce_apis/records/get_lookup_field_suggestions_for_a_specified_object.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -72,6 +72,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_object_metadata.json
+++ b/src/collections/salesforce_apis/records/get_object_metadata.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -24,6 +24,6 @@
   "currentHelper": null,
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_record_data_and_object_metadata.json
+++ b/src/collections/salesforce_apis/records/get_record_data_and_object_metadata.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -67,6 +67,6 @@
   "currentHelper": null,
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_record_layout_metadata.json
+++ b/src/collections/salesforce_apis/records/get_record_layout_metadata.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -49,6 +49,6 @@
   "currentHelper": null,
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_values_for_a_picklist_field.json
+++ b/src/collections/salesforce_apis/records/get_values_for_a_picklist_field.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -24,6 +24,6 @@
   "currentHelper": null,
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/get_values_for_all_picklist_fields_of_a_record_type.json
+++ b/src/collections/salesforce_apis/records/get_values_for_all_picklist_fields_of_a_record_type.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -24,6 +24,6 @@
   "currentHelper": null,
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/records/update_a_record.json
+++ b/src/collections/salesforce_apis/records/update_a_record.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     },
     {
       "description": "",
@@ -45,6 +45,6 @@
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
   "rawModeData": "{\n    \"allowSaveOnDuplicate\": false,\n    \"apiName\": \"Object\",\n    \"fields\": {\n        \"FieldAPIName\": \"FieldValue\"\n    }\n}",
-  "headers": "Authorization: {{_accessToken}}\nContent-Type: application/json\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\nContent-Type: application/json\n",
   "pathVariables": {}
 }

--- a/src/collections/salesforce_apis/ui_api/get_active_theme.json
+++ b/src/collections/salesforce_apis/ui_api/get_active_theme.json
@@ -12,7 +12,7 @@
       "enabled": true,
       "key": "Authorization",
       "type": "text",
-      "value": "{{_accessToken}}"
+      "value": "Bearer {{_accessToken}}"
     }
   ],
   "method": "GET",
@@ -24,6 +24,6 @@
   "currentHelper": null,
   "helperAttributes": null,
   "collectionId": "58651f2c-c011-41d0-b34b-b5609b7d95df",
-  "headers": "Authorization: {{_accessToken}}\n",
+  "headers": "Authorization: Bearer {{_accessToken}}\n",
   "pathVariables": {}
 }


### PR DESCRIPTION
All UI API requests are missing the `Bearer` keyword in their auth header value.
This PR fixes that issue.